### PR TITLE
Make it work on Ruby 1.8.7 and add an archive task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.sw?
 doc
 pkg

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ When you run `rake xcode:build`, `xcodebuild` will be invoked without any argume
       t.configuration = "Release"
     end
 
+_Note that in order to be able to use the `xcode:archive` task, a scheme **has** to be provided_
+
 When you run the rake tasks provided, the default behaviour is to simply output the exact output from `xcodebuild`. However, `xcodebuild-rb` can go one better and allow you to configure custom formatters that change the way the build output is displayed. Some formatters are built-in, or you can write your own.
 
 For instance, we could use the "progress" formatter that ships with `xcodebuild-rb`. Anybody who is used to the output of Ruby's Test::Unit library or RSpec library will be familiar with this.

--- a/Rakefile
+++ b/Rakefile
@@ -14,51 +14,51 @@ task :default => :spec
 
 class InspectReporter
   def build_started(params)
-    pp({build_started: params})
+    pp({:build_started => params})
   end
   
   def clean_step(params)
-    pp({build_step: params})
+    pp({:build_step => params})
   end
   
   def build_error_detected(params)
-    pp({build_error_detected: params})
+    pp({:build_error_detected => params})
   end
   
   def build_succeeded
-    pp({build_succeeded: {}})
+    pp({:build_succeeded => {}})
   end
   
   def build_failed
-    pp({build_failed: {}})
+    pp({:build_failed => {}})
   end
   
   def build_step_failed(params)
-    pp({build_step_failed: params})
+    pp({:build_step_failed => params})
   end
   
   def clean_started(params)
-    pp({clean_started: params})
+    pp({:clean_started => params})
   end
   
   def clean_step(params)
-    pp({clean_step: params})
+    pp({:clean_step => params})
   end
   
   def clean_error_detected(params)
-    pp({clean_error_detected: params})
+    pp({:clean_error_detected => params})
   end
   
   def clean_succeeded
-    pp({clean_succeeded: {}})
+    pp({:clean_succeeded => {}})
   end
   
   def clean_failed
-    pp({clean_failed: {}})
+    pp({:clean_failed => {}})
   end
   
   def clean_step_failed(params)
-    pp({clean_step_failed: params})
+    pp({:clean_step_failed => params})
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,7 @@ end
 
 namespace :examples do
   XcodeBuild::Tasks::BuildTask.new do |t|
+    t.scheme = 'ExampleProject'
     t.invoke_from_within = "resources/ExampleProject"
     t.formatter = XcodeBuild::Formatters::ProgressFormatter.new
     t.after_build do |build|

--- a/bin/rbxcb
+++ b/bin/rbxcb
@@ -1,3 +1,9 @@
 #!/usr/bin/env ruby
-require_relative "../lib/xcodebuild"
+
+if __FILE__ == $0
+  require 'rubygems'
+  $:.unshift(File.expand_path('../../lib', __FILE__))
+end
+
+require "xcode_build"
 XcodeBuild.run(ARGV[0] || "")

--- a/lib/xcode_build.rb
+++ b/lib/xcode_build.rb
@@ -1,3 +1,11 @@
+unless Kernel.respond_to?(:require_relative)
+  module Kernel
+    def require_relative(path)
+      require File.join(File.dirname(caller[0]), path.to_str)
+    end
+  end
+end
+
 module XcodeBuild
   def self.run(args = "", output_buffer = STDOUT)
     IO.popen("xcodebuild #{args} 2>&1") do |io|

--- a/lib/xcode_build.rb
+++ b/lib/xcode_build.rb
@@ -31,6 +31,7 @@ require_relative "xcode_build/build_step"
 require_relative 'xcode_build/output_translator'
 require_relative 'xcode_build/reporter'
 require_relative 'xcode_build/formatters'
+require_relative 'xcode_build/tasks'
 
 # configure the default translations for general use
 XcodeBuild::OutputTranslator.use_translation(:building)

--- a/lib/xcode_build.rb
+++ b/lib/xcode_build.rb
@@ -1,11 +1,3 @@
-unless Kernel.respond_to?(:require_relative)
-  module Kernel
-    def require_relative(path)
-      require File.join(File.dirname(caller[0]), path.to_str)
-    end
-  end
-end
-
 module XcodeBuild
   def self.run(args = "", output_buffer = STDOUT)
     IO.popen("xcodebuild #{args} 2>&1") do |io|
@@ -26,12 +18,12 @@ module XcodeBuild
   end
 end
 
-require_relative "xcode_build/build_action"
-require_relative "xcode_build/build_step"
-require_relative 'xcode_build/output_translator'
-require_relative 'xcode_build/reporter'
-require_relative 'xcode_build/formatters'
-require_relative 'xcode_build/tasks'
+require 'xcode_build/build_action'
+require 'xcode_build/build_step'
+require 'xcode_build/output_translator'
+require 'xcode_build/reporter'
+require 'xcode_build/formatters'
+require 'xcode_build/tasks'
 
 # configure the default translations for general use
 XcodeBuild::OutputTranslator.use_translation(:building)

--- a/lib/xcode_build/build_action.rb
+++ b/lib/xcode_build/build_action.rb
@@ -1,6 +1,6 @@
 require 'state_machine'
 
-require_relative "build_step"
+require "xcode_build/build_step"
 
 module XcodeBuild
   class BuildAction

--- a/lib/xcode_build/formatters.rb
+++ b/lib/xcode_build/formatters.rb
@@ -3,4 +3,4 @@ module XcodeBuild
   end
 end
 
-require_relative "formatters/progress_formatter"
+require "xcode_build/formatters/progress_formatter"

--- a/lib/xcode_build/formatters/progress_formatter.rb
+++ b/lib/xcode_build/formatters/progress_formatter.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require_relative '../utilities/colorize'
+require 'xcode_build/utilities/colorize'
 
 module XcodeBuild
   module Formatters

--- a/lib/xcode_build/output_translator.rb
+++ b/lib/xcode_build/output_translator.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require_relative 'translations'
+require 'xcode_build/translations'
 
 module XcodeBuild
   class OutputTranslator

--- a/lib/xcode_build/output_translator.rb
+++ b/lib/xcode_build/output_translator.rb
@@ -13,7 +13,7 @@ module XcodeBuild
     end
     
     def <<(line)
-      notify_delegate(:beginning_translation_of_line, args: line)
+      notify_delegate(:beginning_translation_of_line, :args => line)
       translations.each { |translation| translation.attempt_to_translate(line) }
     end
     
@@ -56,7 +56,8 @@ module XcodeBuild
     private
     
     module TranslationHelpers
-      def notify_delegate(message, options = {args: []})
+      def notify_delegate(message, options = {})
+        options[:args] ||= []
         if @delegate.respond_to?(message)
           @delegate.send(message, *options[:args])
         else

--- a/lib/xcode_build/reporter.rb
+++ b/lib/xcode_build/reporter.rb
@@ -1,5 +1,5 @@
-require_relative "reporting/build_reporting"
-require_relative "reporting/clean_reporting"
+require "xcode_build/reporting/build_reporting"
+require "xcode_build/reporting/clean_reporting"
 
 module XcodeBuild
   class Reporter

--- a/lib/xcode_build/tasks.rb
+++ b/lib/xcode_build/tasks.rb
@@ -3,4 +3,4 @@ module XcodeBuild
   end
 end
 
-require_relative 'tasks/build_task'
+require 'xcode_build/tasks/build_task'

--- a/lib/xcode_build/tasks.rb
+++ b/lib/xcode_build/tasks.rb
@@ -1,0 +1,6 @@
+module XcodeBuild
+  module Tasks
+  end
+end
+
+require_relative 'tasks/build_task'

--- a/lib/xcode_build/tasks/build_task.rb
+++ b/lib/xcode_build/tasks/build_task.rb
@@ -3,6 +3,8 @@ require 'rake/tasklib'
 module XcodeBuild
   module Tasks
     class BuildTask < ::Rake::TaskLib
+      include Rake::DSL if defined?(Rake::DSL)
+
       attr_accessor :project_name
       attr_accessor :target
       attr_accessor :workspace

--- a/lib/xcode_build/tasks/build_task.rb
+++ b/lib/xcode_build/tasks/build_task.rb
@@ -56,33 +56,37 @@ module XcodeBuild
       end
       
       def build_opts_string(*additional_opts)
-        (build_opts + additional_opts).join(" ")
+        (build_opts + additional_opts).compact.join(" ")
+      end
+
+      def xcodebuild(opt = nil)
+        reporter.direct_raw_output_to = output_to unless formatter
+        
+        status = Dir.chdir(invoke_from_within) do
+          XcodeBuild.run(build_opts_string(opt), output_buffer)
+        end
+        
+        check_status(status)
+
+        @after_build_block.call(reporter.build) if !opt == 'clean' && @after_build_block
       end
 
       def define
         namespace(@namespace) do
+          desc "Creates an archive build of the specified target(s)."
+          task :archive do
+            raise "You need to specify a `scheme' in order to be able to create an archive build!" unless scheme
+            xcodebuild 'archive'
+          end
+
           desc "Builds the specified target(s)."
           task :build do
-            reporter.direct_raw_output_to = output_to unless formatter
-            
-            status = Dir.chdir(invoke_from_within) do
-              XcodeBuild.run(build_opts_string, output_buffer)
-            end
-            
-            check_status(status)
-            
-            @after_build_block.call(reporter.build) if @after_build_block
+            xcodebuild
           end
           
           desc "Cleans the build using the same build settings."
           task :clean do
-            reporter.direct_raw_output_to = output_to unless formatter
-            
-            status = Dir.chdir(invoke_from_within) do
-              XcodeBuild.run(build_opts_string("clean"), output_buffer)
-            end
-            
-            check_status(status)
+            xcodebuild 'clean'
           end
           
           desc "Builds the specified target(s) from a clean slate."

--- a/lib/xcode_build/translations.rb
+++ b/lib/xcode_build/translations.rb
@@ -16,5 +16,5 @@ module XcodeBuild
   end
 end
 
-require_relative "translations/building"
-require_relative "translations/cleaning"
+require "xcode_build/translations/building"
+require "xcode_build/translations/cleaning"

--- a/lib/xcode_build/translations/building.rb
+++ b/lib/xcode_build/translations/building.rb
@@ -59,46 +59,46 @@ module XcodeBuild
           default = false
         end
 
-        notify_delegate(:build_started, required: true, args: [{
-                 target: target,
-                project: project,
-          configuration: configuration,
-                default: default
+        notify_delegate(:build_started, :required => true, :args => [{
+                 :target => target,
+                :project => project,
+          :configuration => configuration,
+                :default => default
         }])
       end
 
       def notify_build_step(line)
-        notify_delegate(:build_step, args: [build_step_from_line(line)])
+        notify_delegate(:build_step, :args => [build_step_from_line(line)])
       end
 
       def notify_build_error(file, line, char, message)
-        notify_delegate(:build_error_detected, args: [{
-             file: file,
-             line: line.to_i,
-             char: char.to_i,
-          message: message
+        notify_delegate(:build_error_detected, :args => [{
+             :file => file,
+             :line => line.to_i,
+             :char => char.to_i,
+          :message => message
         }])
       end
 
       def notify_build_ended(result)
         if result =~ /SUCCEEDED/
-          notify_delegate(:build_succeeded, required: true)
+          notify_delegate(:build_succeeded, :required => true)
         else
-          notify_delegate(:build_failed, required: true)
+          notify_delegate(:build_failed, :required => true)
         end
       end
 
       def notify_build_step_failed(line)
-        notify_delegate(:build_step_failed, args: [build_step_from_line(line)])
+        notify_delegate(:build_step_failed, :args => [build_step_from_line(line)])
       end
       
       def notify_env_var(key, value)
-        notify_delegate(:build_env_variable_detected, args:[key, value])
+        notify_delegate(:build_env_variable_detected, :args => [key, value])
       end
 
       def build_step_from_line(line)
         parts = line.strip.split(" ")
-        {type: parts.shift, arguments: parts}
+        {:type => parts.shift, :arguments => parts}
       end
     end
 

--- a/lib/xcode_build/translations/cleaning.rb
+++ b/lib/xcode_build/translations/cleaning.rb
@@ -57,37 +57,37 @@ module XcodeBuild
           default = false
         end
 
-        notify_delegate(:clean_started, required: true, args: [{
-                 target: target,
-                project: project,
-          configuration: configuration,
-                default: default
+        notify_delegate(:clean_started, :required => true, :args => [{
+                 :target => target,
+                :project => project,
+          :configuration => configuration,
+                :default => default
         }])
       end
       
       def notify_clean_step(line)
-        notify_delegate(:clean_step, args: [clean_step_from_line(line)])
+        notify_delegate(:clean_step, :args => [clean_step_from_line(line)])
       end
       
       def notify_clean_step_failed(line)
-        notify_delegate(:clean_step_failed, args: [clean_step_from_line(line)])
+        notify_delegate(:clean_step_failed, :args => [clean_step_from_line(line)])
       end
       
       def notify_clean_error(message)
-        notify_delegate(:clean_error_detected, args: [{message: message}])
+        notify_delegate(:clean_error_detected, :args => [{:message => message}])
       end
       
       def notify_clean_ended(result)
         if result =~ /SUCCEEDED/
-          notify_delegate(:clean_succeeded, required: true)
+          notify_delegate(:clean_succeeded, :required => true)
         else
-          notify_delegate(:clean_failed, required: true)
+          notify_delegate(:clean_failed, :required => true)
         end
       end
       
       def clean_step_from_line(line)
         parts = line.strip.split(" ")
-        {type: parts.shift, arguments: parts}
+        {:type => parts.shift, :arguments => parts}
       end
     end
 

--- a/lib/xcodebuild.rb
+++ b/lib/xcodebuild.rb
@@ -1,1 +1,1 @@
-require_relative 'xcode_build'
+require 'xcode_build'

--- a/spec/build_task_spec.rb
+++ b/spec/build_task_spec.rb
@@ -99,7 +99,7 @@ describe XcodeBuild::Tasks::BuildTask do
     it "raises if xcodebuild returns a non-zero exit code" do
       task = XcodeBuild::Tasks::BuildTask.new
       XcodeBuild.stub(:run).with(anything, anything).and_return(99)
-      -> { task.run(task_name) }.should raise_error
+      lambda { task.run(task_name) }.should raise_error
     end
     
     it "changes directory if invoke_from_within is set" do

--- a/spec/output_translator_spec.rb
+++ b/spec/output_translator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe XcodeBuild::OutputTranslator do
   let(:delegate)   { mock('delegate') }
-  let(:translator) { XcodeBuild::OutputTranslator.new(delegate, ignore_global_translations: true) }
+  let(:translator) { XcodeBuild::OutputTranslator.new(delegate, :ignore_global_translations => true) }
   
   it "notifies the delegate of each line received (to assist additional processing elsewhere)" do
     delegate.should_receive(:beginning_translation_of_line).with("the line")

--- a/spec/translations/building_translations_spec.rb
+++ b/spec/translations/building_translations_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe XcodeBuild::Translations::Building do
   let(:delegate)    { mock('delegate', :respond_to? => true) }
-  let(:translator)  { XcodeBuild::OutputTranslator.new(delegate, ignore_global_translations: true) }
+  let(:translator)  { XcodeBuild::OutputTranslator.new(delegate, :ignore_global_translations => true) }
   let(:translation) { translator.translations[0] }
   
   before do
@@ -22,10 +22,10 @@ describe XcodeBuild::Translations::Building do
     it "notifies the delegate of the start of a build with the default configuration" do
       delegate.stub(:beginning_translation_of_line)
       delegate.should_receive(:build_started).with(
-                target: "ExampleProject",
-               project: "ExampleProject",
-         configuration: "Release",
-               default: true
+                :target => "ExampleProject",
+               :project => "ExampleProject",
+         :configuration => "Release",
+               :default => true
       )
       translator << "=== BUILD NATIVE TARGET ExampleProject OF PROJECT ExampleProject WITH THE DEFAULT CONFIGURATION (Release) ==="
     end
@@ -33,17 +33,17 @@ describe XcodeBuild::Translations::Building do
     it "notifies the delegate of the start of a build with a non-default configuration" do
       delegate.stub(:beginning_translation_of_line)
       delegate.should_receive(:build_started).with(
-                target: "ExampleProject",
-               project: "ExampleProject",
-         configuration: "Debug",
-               default: false
+                :target => "ExampleProject",
+               :project => "ExampleProject",
+         :configuration => "Debug",
+               :default => false
       )
       translator << "=== BUILD NATIVE TARGET ExampleProject OF PROJECT ExampleProject WITH THE CONFIGURATION Debug ==="
     end
 
     it "treats :build_started as a required delegate message and raise if it doesn't respond" do
       delegate_should_not_respond_to(:build_started)
-      -> { 
+      lambda { 
         translator << "=== BUILD NATIVE TARGET ExampleProject OF PROJECT ExampleProject WITH THE CONFIGURATION Debug ==="
 
       }.should raise_error(XcodeBuild::OutputTranslator::MissingDelegateMethodError)
@@ -57,8 +57,8 @@ describe XcodeBuild::Translations::Building do
     
     it "notifies the delegate of a single build step" do
       delegate.should_receive(:build_step).with(
-             type: "CodeSign", 
-        arguments: ["build/Debug-iphoneos/ExampleProject.app"]
+             :type => "CodeSign", 
+        :arguments => ["build/Debug-iphoneos/ExampleProject.app"]
       )
       translator << "\n"
       translator << "CodeSign build/Debug-iphoneos/ExampleProject.app"
@@ -79,7 +79,7 @@ describe XcodeBuild::Translations::Building do
 
     it "treats :build_failed as a required delegate message and raise if it doesn't respond" do
       delegate_should_not_respond_to(:build_failed)
-      -> { 
+      lambda { 
         translator << "** BUILD FAILED **"
 
       }.should raise_error(XcodeBuild::OutputTranslator::MissingDelegateMethodError)
@@ -93,7 +93,7 @@ describe XcodeBuild::Translations::Building do
 
     it "treats :build_succeeded as a required delegate message and raise if it doesn't respond" do
       delegate_should_not_respond_to(:build_succeeded)
-      -> { 
+      lambda { 
         translator << "** BUILD SUCCEEDED **"
 
       }.should raise_error(XcodeBuild::OutputTranslator::MissingDelegateMethodError)
@@ -101,8 +101,8 @@ describe XcodeBuild::Translations::Building do
 
     it "notifies the delegate of build step failures" do
       delegate.should_receive(:build_step_failed).with(
-             type: "CodeSign", 
-        arguments: ["build/Debug-iphoneos/ExampleProject.app"]
+             :type => "CodeSign", 
+        :arguments => ["build/Debug-iphoneos/ExampleProject.app"]
       )
       translator << "The following build commands failed:"
       translator << "\tCodeSign build/Debug-iphoneos/ExampleProject.app"
@@ -118,20 +118,20 @@ describe XcodeBuild::Translations::Building do
 
     it "notifies the delegate of errors that occur throughout the build" do
       delegate.should_receive(:build_error_detected).with(
-             file: "/ExampleProject/main.m", 
-             line: 16,
-             char: 42,
-          message: "expected ';' after expression [1]"
+             :file => "/ExampleProject/main.m", 
+             :line => 16,
+             :char => 42,
+          :message => "expected ';' after expression [1]"
       )
       translator << "/ExampleProject/main.m:16:42: error: expected ';' after expression [1]"
     end
 
     it "notifies the delegate of errors for different build steps" do
       delegate.should_receive(:build_error_detected).with(
-             file: "/ExampleProject/main.m", 
-             line: 16,
-             char: 42,
-          message: "expected ';' after expression [1]"
+             :file => "/ExampleProject/main.m", 
+             :line => 16,
+             :char => 42,
+          :message => "expected ';' after expression [1]"
       )
 
       translator << "CompileC ExampleProject/main.m normal"
@@ -141,10 +141,10 @@ describe XcodeBuild::Translations::Building do
 
     it "notifies the delegate of multiple errors for the same build step" do
       delegate.should_receive(:build_error_detected).with(
-             file: "/ExampleProject/main.m", 
-             line: 16,
-             char: 42,
-          message: "expected ';' after expression [1]"
+             :file => "/ExampleProject/main.m", 
+             :line => 16,
+             :char => 42,
+          :message => "expected ';' after expression [1]"
       ).twice
 
       translator << "CompileC ExampleProject/main.m normal"

--- a/spec/translations/cleaning_translations_spec.rb
+++ b/spec/translations/cleaning_translations_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe XcodeBuild::OutputTranslator do
   let(:delegate)   { mock('delegate', :respond_to? => true) }
-  let(:translator) { XcodeBuild::OutputTranslator.new(delegate, ignore_global_translations: true) }
+  let(:translator) { XcodeBuild::OutputTranslator.new(delegate, :ignore_global_translations => true) }
   let(:translation) { translator.translations[0] }
 
   before do
@@ -21,27 +21,27 @@ describe XcodeBuild::OutputTranslator do
 
     it "notifies the delegate of the start of a clean with the default configuration" do
       delegate.should_receive(:clean_started).with(
-                target: "ExampleProject",
-               project: "ExampleProject",
-         configuration: "Release",
-               default: true
+                :target => "ExampleProject",
+               :project => "ExampleProject",
+         :configuration => "Release",
+               :default => true
       )
       translator << "=== CLEAN NATIVE TARGET ExampleProject OF PROJECT ExampleProject WITH THE DEFAULT CONFIGURATION (Release) ==="
     end
 
     it "notifies the delegate of the start of a clean with a non-default configuration" do
       delegate.should_receive(:clean_started).with(
-                target: "ExampleProject",
-               project: "ExampleProject",
-         configuration: "Debug",
-               default: false
+                :target => "ExampleProject",
+               :project => "ExampleProject",
+         :configuration => "Debug",
+               :default => false
       )
       translator << "=== CLEAN NATIVE TARGET ExampleProject OF PROJECT ExampleProject WITH THE CONFIGURATION Debug ==="
     end
 
     it "treats :clean_started as a required delegate message and raise if it doesn't respond" do
       delegate_should_not_respond_to(:clean_started)
-      -> {
+      lambda {
         translator << "=== CLEAN NATIVE TARGET ExampleProject OF PROJECT ExampleProject WITH THE CONFIGURATION Debug ==="
 
       }.should raise_error(XcodeBuild::OutputTranslator::MissingDelegateMethodError)
@@ -55,8 +55,8 @@ describe XcodeBuild::OutputTranslator do
 
     it "notifies the delegate of a single clean step" do
       delegate.should_receive(:clean_step).with(
-             type: "Clean.Remove",
-        arguments: ["clean", "build/Release-iphoneos/ExampleProject.app"]
+             :type => "Clean.Remove",
+        :arguments => ["clean", "build/Release-iphoneos/ExampleProject.app"]
       )
       translator << "\n"
       translator << "Clean.Remove clean build/Release-iphoneos/ExampleProject.app"
@@ -70,7 +70,7 @@ describe XcodeBuild::OutputTranslator do
 
     it "treats :clean_failed as a required delegate message and raise if it doesn't respond" do
       delegate_should_not_respond_to(:clean_failed)
-      -> { 
+      lambda {
         translator << "** CLEAN FAILED **"
 
       }.should raise_error(XcodeBuild::OutputTranslator::MissingDelegateMethodError)
@@ -84,7 +84,7 @@ describe XcodeBuild::OutputTranslator do
 
     it "treats :clean_succeeded as a required delegate message and raise if it doesn't respond" do
       delegate_should_not_respond_to(:clean_succeeded)
-      -> {
+      lambda {
         translator << "** CLEAN SUCCEEDED **"
 
       }.should raise_error(XcodeBuild::OutputTranslator::MissingDelegateMethodError)
@@ -92,8 +92,8 @@ describe XcodeBuild::OutputTranslator do
 
     it "notifies the delegate of clean step failures" do
       delegate.should_receive(:clean_step_failed).with(
-             type: "Clean.Remove",
-        arguments: ["clean", "build/Release-iphoneos/ExampleProject.app"]
+             :type => "Clean.Remove",
+        :arguments => ["clean", "build/Release-iphoneos/ExampleProject.app"]
       )
       translator << "The following build commands failed:"
       translator << "\tClean.Remove clean build/Release-iphoneos/ExampleProject.app"
@@ -110,7 +110,7 @@ describe XcodeBuild::OutputTranslator do
 
     it "notifies the delegate of errors for different clean steps" do
       delegate.should_receive(:clean_error_detected).with(
-          message: "Error Domain=NSCocoaErrorDomain Code=513 ExampleProject couldn't be removed"
+          :message => "Error Domain=NSCocoaErrorDomain Code=513 ExampleProject couldn't be removed"
       )
 
       translator << "Clean.Remove clean build/Release-iphoneos/ExampleProject.app"
@@ -121,7 +121,7 @@ describe XcodeBuild::OutputTranslator do
 
     it "notifies the delegate of multiple errors for the same clean step" do
       delegate.should_receive(:clean_error_detected).with(
-          message: "Error Domain=NSCocoaErrorDomain Code=513 ExampleProject couldn't be removed"
+          :message => "Error Domain=NSCocoaErrorDomain Code=513 ExampleProject couldn't be removed"
       ).twice
     
       translator << "Clean.Remove clean build/Release-iphoneos/ExampleProject.app"


### PR DESCRIPTION
This adds the task `xcode:archive`.

The reason to make it work on 1.8.7 is because that’s still what OS X ships with, so using this will make it easier for other devs (contractors) to continue using the tasks without having to install 1.9.x.

There is, however, one problem with failing script phases while archiving, but I will create a separate ticket for that.
