### PR TITLE
Add support for parsing (OCUnit) unit tests

### DIFF
--- a/lib/xcode_build/formatters/progress_formatter.rb
+++ b/lib/xcode_build/formatters/progress_formatter.rb
@@ -37,7 +37,17 @@ module XcodeBuild
       def build_step_finished(step)
         report_step_finished(step)
       end
-      
+
+      def test_step_started(step)
+        $stderr.puts "Hello World!!"
+        puts
+        puts(step.message)
+      end
+
+      def test_step(step)
+        puts(step.message)
+      end
+
       def build_finished(build)
         report_finished(build)
       end

--- a/lib/xcode_build/tasks/build_task.rb
+++ b/lib/xcode_build/tasks/build_task.rb
@@ -18,6 +18,7 @@ module XcodeBuild
       attr_accessor :invoke_from_within
       attr_accessor :reporter_klass
       attr_accessor :xcodebuild_log_path
+      attr_accessor :archive_path
 
       def initialize(namespace = :xcode, &block)
         @namespace = namespace
@@ -63,6 +64,7 @@ module XcodeBuild
           opts << "-arch #{arch}" if arch
           opts << "-sdk #{sdk}" if sdk
           opts << "-xcconfig #{xcconfig}" if xcconfig
+          opts << "-archivePath #{archive_path}" if archive_path
           
           @build_settings.each do |setting, value|
             opts << "#{setting}=#{value}"

--- a/lib/xcode_build/translations.rb
+++ b/lib/xcode_build/translations.rb
@@ -18,3 +18,4 @@ end
 
 require "xcode_build/translations/building"
 require "xcode_build/translations/cleaning"
+require "xcode_build/translations/unit_testing"

--- a/lib/xcode_build/translations/unit_testing.rb
+++ b/lib/xcode_build/translations/unit_testing.rb
@@ -1,0 +1,37 @@
+module XcodeBuild
+  module Translations
+    module UnitTesting
+
+RUN_UNIT_TESTS_ERROR = <<EXPLANATION
+xcodebuild-rb note: This message is caused by a limitation in
+Apple's Xcode RunUnitScripts shell script. In order to run unit
+tests from the command line you need to edit this script as
+described here:
+http://www.stewgleadow.com/blog/2012/02/09/running-ocunit-and-kiwi-tests-on-the-command-line/
+EXPLANATION
+
+      def attempt_to_translate(line)
+        case line
+          when /^(.*)\:(.*)\: warning\: (Skipping tests; .*)$/
+            notify_build_error($1, $2, 0, "#{$3}\n#{RUN_UNIT_TESTS_ERROR}")
+          when /^Test Case '(.*)' started\.$/
+            @in_tests = true
+          when /(.*)\:(\d+)\: error\: (.*)/
+            notify_build_error($1, $2, 0, $3)
+        end
+      end
+
+      def notify_build_error(file, line, char, message)
+        notify_delegate(:build_error_detected, :args => [{
+                                                               :file => file,
+                                                               :line => line.to_i,
+                                                               :char => char.to_i,
+                                                               :message => message
+                                                           }])
+      end
+
+    end
+
+    register_translation :unit_testing, UnitTesting
+  end
+end

--- a/lib/xcode_build/translations/unit_testing.rb
+++ b/lib/xcode_build/translations/unit_testing.rb
@@ -10,10 +10,19 @@ described here:
 http://www.stewgleadow.com/blog/2012/02/09/running-ocunit-and-kiwi-tests-on-the-command-line/
 EXPLANATION
 
+TERMINATING_SINCE_THERE_IS_NO_WORKSPACE_EXPLANATION = <<EXPLANATION
+xcodebuild-rb note: Make sure that you have a workspace set.
+You might also need to explicitly specify the SDK.
+EXPLANATION
+
       def attempt_to_translate(line)
         case line
           when /^(.*)\:(.*)\: warning\: (Skipping tests; .*)$/
             notify_build_error($1, $2, 0, "#{$3}\n#{RUN_UNIT_TESTS_ERROR}")
+          when /^(.*) (Unknown Device Type.*)$/
+            notify_build_warning(nil, 0, 0, $2)
+          when /^(Terminating since .*)$/
+            notify_build_error(nil, 0, 0, "#{$1}\n#{TERMINATING_SINCE_THERE_IS_NO_WORKSPACE_EXPLANATION}")
           when /^Test Case '(.*)' started\.$/
             @in_tests = true
           when /(.*)\:(\d+)\: error\: (.*)/
@@ -23,6 +32,15 @@ EXPLANATION
 
       def notify_build_error(file, line, char, message)
         notify_delegate(:build_error_detected, :args => [{
+                                                               :file => file,
+                                                               :line => line.to_i,
+                                                               :char => char.to_i,
+                                                               :message => message
+                                                           }])
+      end
+
+      def notify_build_warning(file, line, char, message)
+        notify_delegate(:build_warning_detected, :args => [{
                                                                :file => file,
                                                                :line => line.to_i,
                                                                :char => char.to_i,

--- a/lib/xcode_build/translations/unit_testing.rb
+++ b/lib/xcode_build/translations/unit_testing.rb
@@ -23,8 +23,17 @@ EXPLANATION
             notify_build_warning(nil, 0, 0, $2)
           when /^(Terminating since .*)$/
             notify_build_error(nil, 0, 0, "#{$1}\n#{TERMINATING_SINCE_THERE_IS_NO_WORKSPACE_EXPLANATION}")
-          when /^Test Case '(.*)' started\.$/
-            @in_tests = true
+          when /^Test Case .*started\.$/
+            puts
+            puts line
+            #notify_delegate(:test_step_started, :args => [{
+            #                                          :message => line
+            #                                      }])
+          when /^Test Case .*$/
+            puts line
+            #notify_delegate(:test_step, :args => [{
+            #                                          :message => line
+            #                                      }])
           when /(.*)\:(\d+)\: error\: (.*)/
             notify_build_error($1, $2, 0, $3)
         end

--- a/spec/translations/unit_testing_translations_spec.rb
+++ b/spec/translations/unit_testing_translations_spec.rb
@@ -19,7 +19,7 @@ describe XcodeBuild::Translations::UnitTesting do
       translation.stub(:building?).and_return(true)
     end
 
-    it "notifies build failed if the RunUnitTests script has not been fixed" do
+    it "notifies build failed and explanation if the RunUnitTests script has not been fixed" do
       delegate.should_receive(:build_error_detected) do |hash|
         hash[:file].should == "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Tools/Tools/RunPlatformUnitTests"
         hash[:line].should == 95
@@ -46,5 +46,30 @@ describe XcodeBuild::Translations::UnitTesting do
       translator << "Test Case '-[BlahTests testExample]' failed (0.000 seconds)."
     end
 
+    it "notifies build warning for 'Unknown Device Type.'" do
+
+      delegate.should_receive(:build_warning_detected) do |hash|
+        hash[:file].should be_nil
+        hash[:line].should == 0
+        hash[:char].should == 0
+        hash[:message].should =~ /Unknown Device Type/
+      end
+      translator << "\n\n\n"
+      translator << "2012-07-23 15:46:33.589 Blah[23806:11603] Unknown Device Type. Using UIUserInterfaceIdiomPhone based on screen size"
+    end
+
+    it "notifies build error and explanation for 'Terminating since there is no workspace.'" do
+
+      delegate.should_receive(:build_error_detected) do |hash|
+        hash[:file].should be_nil
+        hash[:line].should == 0
+        hash[:char].should == 0
+        hash[:message].should =~ /Terminating since there is no workspace/
+        hash[:message].should =~ /xcodebuild-rb note\:/
+      end
+
+      translator << "\n\n\n"
+      translator << "Terminating since there is no workspace."
+    end
   end
 end

--- a/spec/translations/unit_testing_translations_spec.rb
+++ b/spec/translations/unit_testing_translations_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe XcodeBuild::Translations::UnitTesting do
+  let(:delegate)    { mock('delegate', :respond_to? => true) }
+  let(:translator)  { XcodeBuild::OutputTranslator.new(delegate, :ignore_global_translations => true) }
+  let(:translation) { translator.translations[0] }
+
+  before do
+    translator.use_translation XcodeBuild::Translations::UnitTesting
+
+    delegate_should_respond_to(:beginning_translation_of_line)
+    delegate.stub(:beginning_translation_of_line).and_return(true)
+
+    translator.should have(1).translations
+  end
+
+  context "once a build start has been detected" do
+    before do
+      translation.stub(:building?).and_return(true)
+    end
+
+    it "notifies build failed if the RunUnitTests script has not been fixed" do
+      delegate.should_receive(:build_error_detected) do |hash|
+        hash[:file].should == "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Tools/Tools/RunPlatformUnitTests"
+        hash[:line].should == 95
+        hash[:char].should == 0
+        hash[:message].should =~ /Skipping tests; the iPhoneSimulator platform does not currently support application-hosted tests \(TEST_HOST set\)\./
+        hash[:message].should =~ /xcodebuild-rb note\:/
+      end
+      translator << "\n\n\n"
+      translator << "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Tools/Tools/RunPlatformUnitTests:95: warning: Skipping tests; the iPhoneSimulator platform does not currently support application-hosted tests (TEST_HOST set)."
+    end
+
+    it "notifies build error if a test fails" do
+
+      delegate.should_receive(:build_error_detected) do |hash|
+        hash[:file].should == "/Users/chris/Projects/blah/blah/BlahTests/BlahTests.m"
+        hash[:line].should == 31
+        hash[:char].should == 0
+        hash[:message].should == "-[BlahTests testExample] : Expected <2>, but was <1>"
+      end
+
+      translator << "\n\n\n"
+      translator << "Test Case '-[BlahTests testExample]' started."
+      translator << "/Users/chris/Projects/blah/blah/BlahTests/BlahTests.m:31: error: -[BlahTests testExample] : Expected <2>, but was <1>"
+      translator << "Test Case '-[BlahTests testExample]' failed (0.000 seconds)."
+    end
+
+  end
+end

--- a/spec/translations/unit_testing_translations_spec.rb
+++ b/spec/translations/unit_testing_translations_spec.rb
@@ -33,6 +33,9 @@ describe XcodeBuild::Translations::UnitTesting do
 
     it "notifies build error if a test fails" do
 
+      delegate.stub(:test_step_started)
+      delegate.stub(:test_step)
+
       delegate.should_receive(:build_error_detected) do |hash|
         hash[:file].should == "/Users/chris/Projects/blah/blah/BlahTests/BlahTests.m"
         hash[:line].should == 31
@@ -70,6 +73,26 @@ describe XcodeBuild::Translations::UnitTesting do
 
       translator << "\n\n\n"
       translator << "Terminating since there is no workspace."
+    end
+
+    it "shows test case started messages" do
+
+      delegate.should_receive(:test_step_started) do |hash|
+        hash[:message].should == "Test Case '-[BlahTests testExample]' started."
+      end
+
+      translator << "\n\n\n"
+      translator << "Test Case '-[BlahTests testExample]' started."
+    end
+
+    it "shows test case messages" do
+
+      delegate.should_receive(:test_step) do |hash|
+        hash[:message].should == "Test Case '-[BlahTests testExample]' failed for some reason."
+      end
+
+      translator << "\n\n\n"
+      translator << "Test Case '-[BlahTests testExample]' failed for some reason."
     end
   end
 end


### PR DESCRIPTION
Detect failing unit tests and report them as errors in the build.

Show a detailed warning and fail the build if the RunPlatformUnitTests script error is detected.
See here: http://www.stewgleadow.com/blog/2012/02/09/running-ocunit-and-kiwi-tests-on-the-command-line/

Note that I have not added this to the default ProgressFormatter. 
You need to add the translator explicitly to get it to work:

```
XcodeBuild::OutputTranslator.use_translation(:unit_testing)
t.formatter = XcodeBuild::Formatters::ProgressFormatter.new
```
